### PR TITLE
fixed bottom panel during window resize

### DIFF
--- a/src/main/java/edu/brandeis/cs/nlp/mae/view/MaeMainView.java
+++ b/src/main/java/edu/brandeis/cs/nlp/mae/view/MaeMainView.java
@@ -57,6 +57,9 @@ public class MaeMainView extends JFrame {
         JSplitPane main = new JSplitPane(JSplitPane.VERTICAL_SPLIT, top, bottom);
         main.setDividerLocation(350);
 
+        // ##ES: keep bottom fixed during resize
+        main.setResizeWeight(1.0);
+
         root.add(menuBarView, BorderLayout.NORTH);
         root.add(main, BorderLayout.CENTER);
 


### PR DESCRIPTION
During window resize, bottom panel size will not change, and editor area will be resized only.